### PR TITLE
Linux Support 

### DIFF
--- a/scripts/limbobackground.gd
+++ b/scripts/limbobackground.gd
@@ -41,8 +41,11 @@ func _ready():
 	currentwindow.grab_focus()
 	set_tween_topbg()
 	set_tween_bottombg()
-	# for context: var currentwindow = get_window()
-	self.set_size(currentwindow.get_size())
+	if str(OS.get_name()) == "Linux": # The normal implementation (in the else: statement) doesn't work when compiling for Linux. Havent checked any other OS (ex. MacOS)
+		var h = Vector2i(DisplayServer.screen_get_size()) 
+		self.set_size(h) # This also could fix the issue with larger displays, but I have no way to test since I have an 1080p
+	else:
+		self.set_size(currentwindow.get_size()) # for context: var currentwindow = get_window()
 	if VariableKeeper.sixteen_by_nine_reso or debug:
 		sixteenbyninecontrol.set_size(Vector2((currentwindow.size.y * 16 / 9), currentwindow.size.y))
 		sixteenbyninecontrol.position.x = currentwindow.size.x / 2 - sixteenbyninecontrol.size.x / 2


### PR DESCRIPTION
Changed the way the screen size is taken, seems to work on X11 (w/ Cinnamon, Linux Mint 22.1) and Wayland (XWayland, because Godot lacks Wayland support for now) (w/ KDE Plasma, Fedora 42)

The Windows implementation for fullscreening seems to not work as intended when compiling for Linux, as it makes the `limbobackground` scene fullscreen in 150x150 in the upper left corner, leaving the rest black

This could also work on Windows, but I don't have a way to test it